### PR TITLE
[KMS] CharaSim: Fix escape character in set item tooltip

### DIFF
--- a/WzComparerR2/CharaSimControl/GearGraphics.cs
+++ b/WzComparerR2/CharaSimControl/GearGraphics.cs
@@ -236,7 +236,7 @@ namespace WzComparerR2.CharaSimControl
         /// <param Name="x">起始的x坐标。</param>
         /// <param Name="X1">每行终止的x坐标。</param>
         /// <param Name="y">起始行的y坐标。</param>
-        public static void DrawString(Graphics g, string s, Font font, int x, int x1, ref int y, int height, Color? orangeColor = null)
+        public static void DrawString(Graphics g, string s, Font font, int x, int x1, ref int y, int height, Color? orangeColor = null, Color? textColor = null)
         {
             if (s == null)
                 return;
@@ -245,7 +245,7 @@ namespace WzComparerR2.CharaSimControl
             {
                 r.WordWrapEnabled = false;
                 r.UseGDIRenderer = true;
-                r.DrawString(g, s, font, x, x1, ref y, height, orangeColor);
+                r.DrawString(g, s, font, x, x1, ref y, height, orangeColor, textColor);
             }
         }
 
@@ -530,12 +530,12 @@ namespace WzComparerR2.CharaSimControl
             Color defaultColor;
             Color orangeColor;
 
-            public void DrawString(Graphics g, string s, Font font, int x, int x1, ref int y, int height, Color? orangeColor = null)
+            public void DrawString(Graphics g, string s, Font font, int x, int x1, ref int y, int height, Color? orangeColor = null, Color? textColor = null)
             {
                 //初始化环境
                 this.g = g;
                 this.drawX = x;
-                this.defaultColor = Color.White;
+                this.defaultColor = (textColor == null ? Color.White : (Color)textColor);
                 if (orangeColor != null)
                 {
                     this.orangeColor = (Color)orangeColor;

--- a/WzComparerR2/CharaSimControl/GearGraphics.cs
+++ b/WzComparerR2/CharaSimControl/GearGraphics.cs
@@ -535,7 +535,7 @@ namespace WzComparerR2.CharaSimControl
                 //初始化环境
                 this.g = g;
                 this.drawX = x;
-                this.defaultColor = (textColor == null ? Color.White : (Color)textColor);
+                this.defaultColor = textColor ?? Color.White;
                 if (orangeColor != null)
                 {
                     this.orangeColor = (Color)orangeColor;

--- a/WzComparerR2/CharaSimControl/SetItemTooltipRender.cs
+++ b/WzComparerR2/CharaSimControl/SetItemTooltipRender.cs
@@ -342,7 +342,7 @@ namespace WzComparerR2.CharaSimControl
                         List<Potential> ops = (List<Potential>)prop.Value;
                         foreach (Potential p in ops)
                         {
-                            GearGraphics.DrawString(g, p.ConvertSummary(), GearGraphics.EquipDetailFont2, 10, 244, ref picHeight, 15, null, color);
+                            GearGraphics.DrawString(g, p.ConvertSummary(), GearGraphics.EquipDetailFont2, 10, 244, ref picHeight, 15, textColor: color);
                         }
                     }
                     else if (prop.Key == GearPropType.OptionToMob)

--- a/WzComparerR2/CharaSimControl/SetItemTooltipRender.cs
+++ b/WzComparerR2/CharaSimControl/SetItemTooltipRender.cs
@@ -342,7 +342,7 @@ namespace WzComparerR2.CharaSimControl
                         List<Potential> ops = (List<Potential>)prop.Value;
                         foreach (Potential p in ops)
                         {
-                            GearGraphics.DrawPlainText(g, p.ConvertSummary(), GearGraphics.EquipDetailFont2, color, 10, 244, ref picHeight, 15);
+                            GearGraphics.DrawString(g, p.ConvertSummary(), GearGraphics.EquipDetailFont2, 10, 244, ref picHeight, 15, null, color);
                         }
                     }
                     else if (prop.Key == GearPropType.OptionToMob)


### PR DESCRIPTION
![diff](https://user-images.githubusercontent.com/11611397/91925193-77e4d800-ed0f-11ea-8530-cdb862ebc357.png)

- 대상: `Etc\SetItemInfo.img\25` 라이온하트 세트
- 옵션: `Item\ItemOption.img\030107\info\string` : 모든 스킬레벨 : +#incAllskill(5차 및 일부 스킬 제외,\n스킬의 마스터 레벨까지만 증가)

세트아이템 옵션에 \n가 들어가는 경우가 있어서 DrawPlainText를 DrawString로 바꿔줬고, DrawString이 텍스트 지정하는 파라미터가 없어서 추가했습니다