### PR TITLE
Support Level Point (Fix #59)

### DIFF
--- a/WzComparerR2.Common/CharaSim/GearLevelInfo.cs
+++ b/WzComparerR2.Common/CharaSim/GearLevelInfo.cs
@@ -17,6 +17,8 @@ namespace WzComparerR2.CharaSim
         public int Level { get; set; }
         public Dictionary<GearPropType, Range> BonusProps { get; private set; }
         public int Exp { get; set; }
+        public int Point { get; set; }
+        public int DecPoint { get; set; }
 
         public string HS { get; set; }
         public int Prob { get; set; }
@@ -33,6 +35,14 @@ namespace WzComparerR2.CharaSim
                 if (child.Text == "exp")
                 {
                     info.Exp = child.GetValue(0);
+                }
+                else if (child.Text == "point")
+                {
+                    info.Point = child.GetValue(0);
+                }
+                else if (child.Text == "decPoint")
+                {
+                    info.DecPoint = child.GetValue(0);
                 }
                 else 
                 {

--- a/WzComparerR2/CharaSimControl/GearTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/GearTooltipRender2.cs
@@ -399,15 +399,8 @@ namespace WzComparerR2.CharaSimControl
                 bool max = (Gear.Levels != null && value >= Gear.Levels.Count);
                 TextRenderer.DrawText(g, "성장 레벨 : " + (max ? "MAX" : value.ToString()), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
                 picH += 15;
-
-                if (Gear.Levels != null)
-                {
-                    TextRenderer.DrawText(g, "성장 경험치" + (max ? ": MAX" : " : 0/" + Gear.Levels.First().Point), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
-                }
-                else
-                {
-                    TextRenderer.DrawText(g, "성장 경험치" + (max ? ": MAX" : " : 0%"), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
-                }
+                string expString = Gear.Levels != null ? " : 0/" + Gear.Levels.First().Point : " : 0%";
+                TextRenderer.DrawText(g, "성장 경험치" + (max ? ": MAX" : expString), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
                 picH += 15;
             }
             else if (Gear.ItemID / 10000 == 171)

--- a/WzComparerR2/CharaSimControl/GearTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/GearTooltipRender2.cs
@@ -399,7 +399,15 @@ namespace WzComparerR2.CharaSimControl
                 bool max = (Gear.Levels != null && value >= Gear.Levels.Count);
                 TextRenderer.DrawText(g, "성장 레벨 : " + (max ? "MAX" : value.ToString()), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
                 picH += 15;
-                TextRenderer.DrawText(g, "성장 경험치" + (max ? ": MAX" : " : 0%"), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
+
+                if (Gear.Levels != null)
+                {
+                    TextRenderer.DrawText(g, "성장 경험치" + (max ? ": MAX" : " : 0/" + Gear.Levels.First().Point), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
+                }
+                else
+                {
+                    TextRenderer.DrawText(g, "성장 경험치" + (max ? ": MAX" : " : 0%"), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
+                }
                 picH += 15;
             }
             else if (Gear.ItemID / 10000 == 171)
@@ -1072,6 +1080,11 @@ namespace WzComparerR2.CharaSimControl
                     if (info.Exp > 0)
                     {
                         TextRenderer.DrawText(g, "단위 경험치 : " + info.Exp + "%", GearGraphics.EquipDetailFont, new Point(10, picHeight), Color.White, TextFormatFlags.NoPadding);
+                        picHeight += 15;
+                    }
+                    if (info.Point > 0 && info.DecPoint > 0)
+                    {
+                        TextRenderer.DrawText(g, "경험치 (-일간 감소량) : " + info.Point + " (-" + info.DecPoint + ")", GearGraphics.EquipDetailFont, new Point(10, picHeight), Color.White, TextFormatFlags.NoPadding);
                         picHeight += 15;
                     }
 


### PR DESCRIPTION
![1162018](https://user-images.githubusercontent.com/11611397/92305248-7a218d80-efc0-11ea-91db-f2ac5e0ca463.png)

레벨 정보에도 추가했는데 경험치랑 줄어드는 양 각각 쓰니까 너무 길어지는 것 같아서 한줄로 합쳤습니다.

수정하면서 빠진 부분이 있는지 모르겠네요