### PR TITLE
Support Multiple Additional Tooltips (Fix #58) && Fix bug with item exp

### DIFF
--- a/WzComparerR2.Common/CharaSim/Item.cs
+++ b/WzComparerR2.Common/CharaSim/Item.cs
@@ -12,6 +12,7 @@ namespace WzComparerR2.CharaSim
         {
             this.Props = new Dictionary<ItemPropType, int>();
             this.Specs = new Dictionary<ItemSpecType, int>();
+            this.AddTooltips = new List<int>();
         }
 
         public int Level { get; set; }
@@ -22,6 +23,7 @@ namespace WzComparerR2.CharaSim
 
         public Dictionary<ItemPropType, int> Props { get; private set; }
         public Dictionary<ItemSpecType, int> Specs { get; private set; }
+        public List<int> AddTooltips { get; internal set; } // Additional Tooltips
 
         public bool Cash
         {
@@ -213,6 +215,20 @@ namespace WzComparerR2.CharaSim
                                 }
                             }
                             item.Props.Add(ItemPropType.level, 1);
+                            break;
+
+                        case "addTooltip":
+                            if (subNode.Nodes.Count > 0)
+                            {
+                                foreach (Wz_Node tooltipNode in subNode.Nodes)
+                                {
+                                    item.AddTooltips.Add(Convert.ToInt32(tooltipNode.Value));
+                                }
+                            }
+                            else
+                            {
+                                item.AddTooltips.Add(Convert.ToInt32(subNode.Value));
+                            }
                             break;
 
                         default:

--- a/WzComparerR2.Common/CharaSim/ItemPropType.cs
+++ b/WzComparerR2.Common/CharaSim/ItemPropType.cs
@@ -47,7 +47,6 @@ namespace WzComparerR2.CharaSim
         consumeMP,
         autoBuff,
         giantPet,
-        addTooltip,
         useTradeBlock,
         level,
         sharableOnce,

--- a/WzComparerR2/CharaSimControl/GearTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/GearTooltipRender2.cs
@@ -399,7 +399,7 @@ namespace WzComparerR2.CharaSimControl
                 bool max = (Gear.Levels != null && value >= Gear.Levels.Count);
                 TextRenderer.DrawText(g, "성장 레벨 : " + (max ? "MAX" : value.ToString()), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
                 picH += 15;
-                string expString = Gear.Levels != null ? " : 0/" + Gear.Levels.First().Point : " : 0%";
+                string expString = Gear.Levels != null && Gear.Levels.First().Point != 0 ? " : 0/" + Gear.Levels.First().Point : " : 0%";
                 TextRenderer.DrawText(g, "성장 경험치" + (max ? ": MAX" : expString), GearGraphics.EquipDetailFont, new Point(13, picH), ((SolidBrush)GearGraphics.OrangeBrush3).Color, TextFormatFlags.NoPadding);
                 picH += 15;
             }

--- a/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
@@ -159,54 +159,10 @@ namespace WzComparerR2.CharaSimControl
             }
 
             int value;
-            if (this.item.Props.TryGetValue(ItemPropType.dressUpgrade, out value) || this.item.Props.TryGetValue(ItemPropType.addTooltip, out value))
+            if (this.item.Props.TryGetValue(ItemPropType.dressUpgrade, out value))
             {
                 int itemID = value;
-                int itemIDClass = itemID / 1000000;
-                if (itemIDClass == 1) //通过ID寻找装备
-                {
-                    Wz_Node charaWz = PluginManager.FindWz(Wz_Type.Character);
-                    if (charaWz != null)
-                    {
-                        string imgName = itemID.ToString("d8") + ".img";
-                        foreach (Wz_Node node0 in charaWz.Nodes)
-                        {
-                            Wz_Node imgNode = node0.FindNodeByPath(imgName, true);
-                            if (imgNode != null)
-                            {
-                                Gear gear = Gear.CreateFromNode(imgNode, path=>PluginManager.FindWz(path));
-                                if (gear != null)
-                                {
-                                    recipeItemBmp = RenderLinkRecipeGear(gear);
-                                }
-
-                                break;
-                            }
-                        }
-                    }
-                }
-                else if (itemIDClass >= 2 && itemIDClass <= 5) //通过ID寻找道具
-                {
-                    Wz_Node itemWz = PluginManager.FindWz(Wz_Type.Item);
-                    if (itemWz != null)
-                    {
-                        string imgClass = (itemID / 10000).ToString("d4") + ".img\\" + itemID.ToString("d8");
-                        foreach (Wz_Node node0 in itemWz.Nodes)
-                        {
-                            Wz_Node imgNode = node0.FindNodeByPath(imgClass, true);
-                            if (imgNode != null)
-                            {
-                                Item item = Item.CreateFromNode(imgNode, PluginManager.FindWz);
-                                if (item != null)
-                                {
-                                    recipeItemBmp = RenderLinkRecipeItem(item);
-                                }
-
-                                break;
-                            }
-                        }
-                    }
-                }
+                AppendGearOrItem(itemID);
             }
 
             int setID;

--- a/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
@@ -165,6 +165,14 @@ namespace WzComparerR2.CharaSimControl
                 AppendGearOrItem(itemID);
             }
 
+            if (this.item.AddTooltips.Count > 0)
+            {
+                foreach (int itemID in item.AddTooltips)
+                {
+                    AppendGearOrItem(itemID);
+                }
+            }
+
             int setID;
             if (this.item.Props.TryGetValue(ItemPropType.setItemID, out setID))
             {
@@ -178,24 +186,29 @@ namespace WzComparerR2.CharaSimControl
             //计算布局
             Size totalSize = new Size(itemBmp.Width, picHeight);
             Point recipeInfoOrigin = Point.Empty;
-            Point recipeItemOrigin = Point.Empty;
+            List<Point> recipeItemOrigins = new List<Point>();
             Point setItemOrigin = Point.Empty;
             Point levelOrigin = Point.Empty;
 
-            if (recipeItemBmp != null)
+            if (recipeItemBmps.Count > 0)
             {
-                recipeItemOrigin.X = totalSize.Width;
-                totalSize.Width += recipeItemBmp.Width;
-
                 if (recipeInfoBmp != null)
                 {
+                    recipeItemOrigins.Add(new Point(totalSize.Width, 0));
                     recipeInfoOrigin.X = itemBmp.Width - recipeInfoBmp.Width;
                     recipeInfoOrigin.Y = picHeight;
-                    totalSize.Height = Math.Max(picHeight + recipeInfoBmp.Height, recipeItemBmp.Height);
+                    totalSize.Width += recipeItemBmps[0].Width;
+                    totalSize.Height = Math.Max(picHeight + recipeInfoBmp.Height, recipeItemBmps[0].Height);
                 }
                 else
                 {
-                    totalSize.Height = Math.Max(picHeight, recipeItemBmp.Height);
+                    int itemCnt = recipeItemBmps.Count;
+                    for (int i = 0; i < itemCnt; ++i)
+                    {
+                        recipeItemOrigins.Add(new Point(totalSize.Width, 0));
+                        totalSize.Width += recipeItemBmps[i].Width;
+                        totalSize.Height = Math.Max(picHeight, recipeItemBmps[i].Height);
+                    }
                 }
             }
             else if (recipeInfoBmp != null)
@@ -244,10 +257,14 @@ namespace WzComparerR2.CharaSimControl
             }
 
             //绘制产出道具
-            if (recipeItemBmp != null)
+            if (recipeItemBmps.Count > 0)
             {
-                g.DrawImage(recipeItemBmp, recipeItemOrigin.X, recipeItemOrigin.Y,
-                    new Rectangle(Point.Empty, recipeItemBmp.Size), GraphicsUnit.Pixel);
+                int itemCnt = recipeItemBmps.Count;
+                for (int i = 0; i < itemCnt; ++i)
+                {
+                    g.DrawImage(recipeItemBmps[i], recipeItemOrigins[i].X, recipeItemOrigins[i].Y,
+                        new Rectangle(Point.Empty, recipeItemBmps[i].Size), GraphicsUnit.Pixel);
+                }
             }
 
             //绘制套装
@@ -269,8 +286,9 @@ namespace WzComparerR2.CharaSimControl
                 itemBmp.Dispose();
             if (recipeInfoBmp != null)
                 recipeInfoBmp.Dispose();
-            if (recipeItemBmp != null)
-                recipeItemBmp.Dispose();
+            if (recipeItemBmps.Count > 0)
+                foreach (Bitmap recipeItemBmp in recipeItemBmps)
+                    recipeItemBmp.Dispose();
             if (setItemBmp != null)
                 setItemBmp.Dispose();
             if (levelBmp != null)


### PR DESCRIPTION
![11](https://user-images.githubusercontent.com/11611397/92321244-6d09aa80-f063-11ea-819e-294bb0ae8528.png)
![22](https://user-images.githubusercontent.com/11611397/92321245-6e3ad780-f063-11ea-995c-8e16ed7db16f.png)

Item Property에서 AddTooltip을 빼고 item에 List&lt;int&gt; AddTooltips를 추가했습니다.

Render 함수에서 중복되는 코드가 있어서 Action으로 묶었습니다.

![33](https://user-images.githubusercontent.com/11611397/92322032-c674d800-f069-11ea-9812-83b0163d83a7.png)

확인하다보니 Level은 있는데 각 레벨마다 point, decPoint가 없는 아이템의 성장경험치가 0%가 아니라 0/0으로 표시됐는데, 올바르게 출력되게 해놨습니다