### PR TITLE
Fix commodity.termEnd type error

### DIFF
--- a/WzComparerR2.Common/CharaSim/Commodity.cs
+++ b/WzComparerR2.Common/CharaSim/Commodity.cs
@@ -115,7 +115,11 @@ namespace WzComparerR2.CharaSim
                         commodity.termStart = Convert.ToInt32(subNode.Value);
                         break;
                     case "termEnd":
-                        commodity.termEnd = Convert.ToInt32(subNode.Value);
+                        string value = Convert.ToString(subNode.Value);
+                        if(!Int32.TryParse(value, out commodity.termEnd))
+                        {
+                            commodity.termEnd = Convert.ToInt32(value.Split('/')[0] + value.Split('/')[1].Substring(0, 2));
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
Etc/Commodity/0/termEnd의 값이 "2020121624" -> "20201216/235959"로 바뀌어 발생하는 오류를 수정합니다. (#64)