### PR TITLE
fix Potential.CheckOptionType

### DIFF
--- a/WzComparerR2.Common/CharaSim/Potential.cs
+++ b/WzComparerR2.Common/CharaSim/Potential.cs
@@ -61,8 +61,9 @@ namespace WzComparerR2.CharaSim
             switch (optionType)
             {
                 case 0: return true;
-                case 10: return Gear.IsWeapon(gearType) || 
-                    (Gear.IsSubWeapon(gearType) && gearType != GearType.shield);
+                case 10: return Gear.IsWeapon(gearType) 
+                    || Gear.IsSubWeapon(gearType) // IsSubWeapon should return `true` for GearType.katara
+                    || gearType == GearType.shield;
                 case 11:
                     return !CheckOptionType(10, gearType);
                 case 20: return gearType == GearType.pants


### PR DESCRIPTION
Reference: https://maplestory.nexon.com/Guide/OtherProbability/cube/red

For rare grade, gearType=weapon, subweapon, soulring and shield all contains option 10201 and 10206. (공격 시 #prop% 확률로 #HP의 HP 회복, 공격 시 #prop% 확률로 #MP의 MP 회복) They all have optionType 10. Added gearTypes which contains those options.