### PR TITLE
Fix: Cannot open UIWorldMap on old client

### DIFF
--- a/WzComparerR2.MapRender/UI/UIWorldMap.cs
+++ b/WzComparerR2.MapRender/UI/UIWorldMap.cs
@@ -223,8 +223,8 @@ namespace WzComparerR2.MapRender.UI
             var uiNode = PluginBase.PluginManager.FindWz("UI/UIWindow2.img/WorldMap");
             foreach (var search in new[] { "worldSearch", "regionSearch1", "regionSearch2", "regionSearch3" })
             {
-                var searchNode = uiNode.FindNodeByPath("combo:" + search + "\\contents\\" + search);
-                foreach (var unitNode in searchNode.Nodes)
+                var searchNode = uiNode?.FindNodeByPath("combo:" + search + "\\contents\\" + search);
+                foreach (var unitNode in searchNode?.Nodes ?? new Wz_Node.WzNodeCollection(null))
                 {
                     string dataValue = unitNode.Nodes["data"].GetValueEx<string>(null);
                     string stringValue = unitNode.Nodes["string"].GetValueEx<string>(null);


### PR DESCRIPTION
![캡처](https://user-images.githubusercontent.com/101188238/216779620-47c045aa-9c1c-4431-9baa-642f306d6921.PNG)

UI/UIWindow2.img/WorldMap이 없거나
해당 경로에 combo:...가 없는 경우
월드맵이 열리지 않아서 수정했습니다
