### PR TITLE
Updating the MapRender to filter by Mob node property "minimap"

### DIFF
--- a/WzComparerR2.MapRender/FrmMapRender2.SceneManager.cs
+++ b/WzComparerR2.MapRender/FrmMapRender2.SceneManager.cs
@@ -326,9 +326,10 @@ namespace WzComparerR2.MapRender
                     });
                 }
             }
-            if (mapData.MapMark == "MonsterPark" || string.Compare(mapData.FieldScript, "morassDQ", StringComparison.OrdinalIgnoreCase) == 0)
+            foreach (var mob in mapData.Scene.Mobs)
             {
-                foreach (var mob in mapData.Scene.Mobs)
+                var mobNode = PluginManager.FindWz(string.Format("Mob/{0:D7}.img/info", mob.ID));
+                if ((mobNode?.Nodes["minimap"].GetValueEx(0) ?? 0) != 0)
                 {
                     this.ui.Minimap.Icons.Add(new UIMinimap2.MapIcon()
                     {


### PR DESCRIPTION
I've updated the MapRender to look for the Mob node property `minimap` instead of the Map Mark `MonsterPark` or the Map fieldScript `morassDQ`, to account for other monsters with the same property.

Now it will look for other monsters with the property `minimap`, such as some quest monsters from Odium.
![image](https://github.com/KENNYSOFT/WzComparerR2/assets/34289651/1bd92844-a2ba-4df2-8e7a-ef8157e74a30)

Map ID 993217200:
![image](https://github.com/KENNYSOFT/WzComparerR2/assets/34289651/69ee7b2f-bef5-4b40-ae79-a4b60f0ea3ab)

Map IDs 993217110, 993217140, and 993217170 also work as expected, same as Monster Park and the 3 Morass daily quest maps.

Also tested in my own fork, map ID 993217170:
![image](https://github.com/KENNYSOFT/WzComparerR2/assets/34289651/e2ae511e-6ff0-45d3-952f-8cc63ce0ebbb)
