### PR TITLE
Avatar: Fix Load from Code

### DIFF
--- a/WzComparerR2.Avatar/UI/AvatarForm.cs
+++ b/WzComparerR2.Avatar/UI/AvatarForm.cs
@@ -1594,6 +1594,11 @@ namespace WzComparerR2.Avatar.UI
 
             foreach (var node1 in characWz.Nodes)
             {
+                if (node1.Text.Contains("_Canvas"))
+                {
+                    continue;
+                }
+
                 if (node1.Text == imgName)
                 {
                     imgNode = node1;


### PR DESCRIPTION
코드로 아이템 검색 시 _Canvas 노드를 우선적으로 찾아서, body part의 경우 info노드가 없는 노드가 검색되어, 화면에 출력되지 않는 현상을 수정했습니다.
<br>

- 오류화면

![cc1](https://github.com/KENNYSOFT/WzComparerR2/assets/101188238/e5a7d5eb-4147-4621-8903-4191667557b9)
