### PR TITLE
추가옵션 재설정 불가 출력

### DIFF
--- a/WzComparerR2.Common/CharaSim/GearPropType.cs
+++ b/WzComparerR2.Common/CharaSim/GearPropType.cs
@@ -189,6 +189,7 @@ namespace WzComparerR2.CharaSim
         tucIgnoreForPotential,
         Etuc,
         CuttableCount,
+        exUpgradeChangeBlock,
 
         gatherTool_incSkillLevel = 2000,
         gatherTool_incSpeed,

--- a/WzComparerR2/CharaSimControl/GearTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/GearTooltipRender2.cs
@@ -630,6 +630,11 @@ namespace WzComparerR2.CharaSimControl
                 TextRenderer.DrawText(g, "에디셔널 잠재능력 설정 불가", GearGraphics.EquipDetailFont, new Point(13, picH), Color.White, TextFormatFlags.NoPadding);
                 picH += 15;
             }
+            if (Gear.Props.TryGetValue(GearPropType.exUpgradeChangeBlock, out value) && value > 0)
+            {
+                TextRenderer.DrawText(g, "추가옵션 재설정 불가", GearGraphics.EquipDetailFont, new Point(13, picH), Color.White, TextFormatFlags.NoPadding);
+                picH += 15;
+            }
 
             //星星锤子
             if (hasTuc && Gear.Hammer > -1 && Gear.GetMaxStar() > 0)


### PR DESCRIPTION
세 가지를 pr로 하려고 했는데,
이올렛 장비의 잠재능력 관련 문구는 일단 인게임에서 따로 처리 없이 desc로 끝난 거 같아서 뺐고,
Etuc는 이미 적용되어 있는 것 같아서 뺐고...
남은게 추가옵션 재설정 불가네요.

pr 하는 방법을 터득해서 올려봅니다...


![EF60FECA890DB8E82](https://github.com/user-attachments/assets/7a4b1cd7-fd47-4a70-8aa7-40659523a1a6)
![1482244](https://github.com/user-attachments/assets/a0ec5885-8f8f-4641-8ab6-be0eb854a70c)
